### PR TITLE
Add option for HOST to config/app.js

### DIFF
--- a/config/app.js
+++ b/config/app.js
@@ -30,6 +30,19 @@ module.exports = {
 
   /**
    * --------------------------------------------------------------------------
+   * Web Application Host
+   * --------------------------------------------------------------------------
+   *
+   * This is default host your hapi web server will bind to. You
+   * can change this to a specific IP (0.0.0.0, 192.168.0.1 ) to 
+   * support the requirements of your application.
+   *
+   */
+
+  host: Env.get('HOST', 'localhost'),
+  
+  /**
+   * --------------------------------------------------------------------------
    * Web Application Port
    * --------------------------------------------------------------------------
    *


### PR DESCRIPTION
Binding the host to 'localhost' is not always ideal.  

For example, if placing your application inside Docker, you must bind to 0.0.0.0.  Or perhaps you're on a physical machine, and need to bind to a specific IP address (192.168.0.1).

This code adds the configuration option.  

To make this work, another modification is required.  A small code change in the supercharge foundation repository:
     **./framework/src/foundation/http/kernel.js**

I will submit that pull request also.